### PR TITLE
Update benchmark

### DIFF
--- a/benchmark
+++ b/benchmark
@@ -80,11 +80,54 @@ benchmark(_, _) ->
     usage().
 
 benchmark_marray(Marray) ->
-    quicksort(Marray).
+    sort(Marray, marray:size(Marray)).
 
-quicksort(Marray) ->
-    R = marray:size(Marray) - 1,
-    quicksort(Marray, 0, R).
+sort(Marray, 0) ->
+    Marray;
+sort(Marray, 1) ->
+    Marray;
+sort(Marray, 2) ->
+    Val1 = marray:get(Marray, 0),
+    Val2 = marray:get(Marray, 1),
+    case Val1 < Val2 of
+        true ->
+            Marray;
+        false ->
+            marray:swap(Marray, 0, 1)
+    end;
+sort(Marray, 3) ->
+    Val1 = marray:get(Marray, 0),
+    Val2 = marray:get(Marray, 1),
+    Val3 = marray:get(Marray, 2),
+    case Val1 < Val2 of
+        true ->
+            case Val2 < Val3 of
+                true ->
+                    Marray;
+                false ->
+                    case Val1 < Val3 of
+                        true ->
+                            marray:swap(Marray, 1, 2);
+                        false ->
+                            marray:swap(Marray, 0, 2)
+                    end
+            end;
+        false ->
+            case Val1 < Val3 of
+                true ->
+                    marray:swap(Marray, 0, 1);
+                false ->
+                    case Val2 < Val3 of
+                        true ->
+                            marray:swap(Marray, 0, 2);
+                        false ->
+                            marray:swap(Marray, 0, 1),
+                            marray:swap(Marray, 1, 2)
+                    end
+            end
+    end;
+sort(Marray, N) ->
+    quicksort(Marray, 0, N - 1).
 
 quicksort(Marray, L, R) when L < R ->
     PivotIndex = partition(Marray, L, R),
@@ -94,7 +137,47 @@ quicksort(Marray, _L, _R) ->
     Marray.
 
 partition(Marray, L, R) ->
-    Pivot = marray:get(Marray, R),
+    Pivot = case R - L of
+        0 ->
+            marray:get(Marray, R);
+        1 ->
+            marray:get(Marray, R);
+        _ ->
+            P = L + round((R - L) / 2),
+            Val1 = marray:get(Marray, L),
+            Val2 = marray:get(Marray, P),
+            Val3 = marray:get(Marray, R),
+            case Val1 < Val2 of
+                true ->
+                    case Val2 < Val3 of
+                        true ->
+                            marray:swap(Marray, P, R),
+                            Val2;
+                        false ->
+                            case Val1 < Val3 of
+                                true ->
+                                    Val3;
+                                false ->
+                                    marray:swap(Marray, L, R),
+                                    Val1
+                            end
+                    end;
+                false ->
+                    case Val1 < Val3 of
+                        true ->
+                            marray:swap(Marray, L, R),
+                            Val1;
+                        false ->
+                            case Val2 < Val3 of
+                                true ->
+                                    marray:get(Marray, R);
+                                false ->
+                                    marray:swap(Marray, P, R),
+                                    Val2
+                            end
+                    end
+            end
+    end,
     I = partition(R, L, L - 1, Pivot, Marray),
     marray:swap(Marray, I + 1, R),
     I + 1.

--- a/benchmark
+++ b/benchmark
@@ -13,8 +13,8 @@ main([REPEAT_TIMES | ARRAY_LENGTH]) ->
             ARRAY_LENGTH
         )
     catch
-        A:B ->
-            io:format("Error: ~p: ~p~n", [A, B]),
+        A:B:C ->
+            io:format("Error: ~p: ~p~n~p~n", [A, B, C]),
             usage()
     end;
 main(_) ->
@@ -35,13 +35,20 @@ generate_list(N, Acc) ->
 benchmark(N, R) when N > 0 ->
     io:format("Benchmarking with array length ~p~n", [N]),
     Benchmark = fun(Fun) ->
-        {Time, _} = timer:tc(Fun, microsecond),
-        Time
+        {_Pid, Ref} = spawn_monitor(fun() ->
+            {Time, _} = timer:tc(Fun, []),
+            exit(Time)
+        end),
+        receive
+          {'DOWN', Ref, _, _, Time} -> Time
+        end
     end,
     ElapsedTimes = lists:map(
         fun(_I) ->
             List = generate_list(N),
             Marray = marray:from_list(List),
+            %% Assert the results match
+            true = (marray:to_list(benchmark_marray(Marray)) =:= benchmark_list(List)),
             [
               Benchmark(fun() -> benchmark_marray(Marray) end),
               Benchmark(fun() -> benchmark_list(List) end)
@@ -73,8 +80,7 @@ benchmark(_, _) ->
     usage().
 
 benchmark_marray(Marray) ->
-    quicksort(Marray),
-    ok.
+    quicksort(Marray).
 
 quicksort(Marray) ->
     R = marray:size(Marray) - 1,
@@ -89,27 +95,24 @@ quicksort(Marray, _L, _R) ->
 
 partition(Marray, L, R) ->
     Pivot = marray:get(Marray, R),
-    Indices = lists:seq(L, R - 1),
-    I = lists:foldr(
-        fun(Index, I) ->
-            Val = marray:get(Marray, Index),
-            case Val < Pivot of
-                true ->
-                    marray:swap(Marray, I + 1, Index),
-                    I + 1;
-                false ->
-                    I
-            end
-        end,
-        L - 1,
-        Indices
-    ),
+    I = partition(R - 1, L, L - 1, Pivot, Marray),
     marray:swap(Marray, I + 1, R),
     I + 1.
 
+partition(R, L, I, Pivot, Marray) when R >= L ->
+    Val = marray:get(Marray, R),
+    case Val < Pivot of
+        true ->
+            marray:swap(Marray, I + 1, R),
+            partition(R - 1, L, I + 1, Pivot, Marray);
+        false ->
+            partition(R - 1, L, I, Pivot, Marray)
+    end;
+partition(_R, _L, I, _Pivot, _Marray) ->
+    I.
+
 benchmark_list(List) ->
-    qsort(List),
-    ok.
+    qsort(List).
 
 qsort([]) ->
     [];

--- a/benchmark
+++ b/benchmark
@@ -48,7 +48,7 @@ benchmark(N, R) when N > 0 ->
             List = generate_list(N),
             Marray = marray:from_list(List),
             %% Assert the results match
-            true = (marray:to_list(benchmark_marray(Marray)) =:= benchmark_list(List)),
+            true = (marray:to_list(benchmark_marray(marray:from_list(List))) =:= benchmark_list(List)),
             [
               Benchmark(fun() -> benchmark_marray(Marray) end),
               Benchmark(fun() -> benchmark_list(List) end)
@@ -95,18 +95,18 @@ quicksort(Marray, _L, _R) ->
 
 partition(Marray, L, R) ->
     Pivot = marray:get(Marray, R),
-    I = partition(R - 1, L, L - 1, Pivot, Marray),
+    I = partition(R, L, L - 1, Pivot, Marray),
     marray:swap(Marray, I + 1, R),
     I + 1.
 
-partition(R, L, I, Pivot, Marray) when R >= L ->
-    Val = marray:get(Marray, R),
+partition(R, L, I, Pivot, Marray) when L =< R ->
+    Val = marray:get(Marray, L),
     case Val < Pivot of
         true ->
-            marray:swap(Marray, I + 1, R),
-            partition(R - 1, L, I + 1, Pivot, Marray);
+            marray:swap(Marray, I + 1, L),
+            partition(R, L + 1, I + 1, Pivot, Marray);
         false ->
-            partition(R - 1, L, I, Pivot, Marray)
+            partition(R, L + 1, I, Pivot, Marray)
     end;
 partition(_R, _L, I, _Pivot, _Marray) ->
     I.

--- a/benchmark
+++ b/benchmark
@@ -48,39 +48,48 @@ benchmark(N, R) when N > 0 ->
             List = generate_list(N),
             Marray = marray:from_list(List),
             %% Assert the results match
-            true = (marray:to_list(benchmark_marray(marray:from_list(List))) =:= benchmark_list(List)),
+            true = (marray:to_list(benchmark_marray(marray:from_list(List), c_sort)) =:= benchmark_list(List)),
             [
-              Benchmark(fun() -> benchmark_marray(Marray) end),
+              Benchmark(fun() -> benchmark_marray(Marray, erlang) end),
+              Benchmark(fun() -> benchmark_marray(Marray, c_sort) end),
               Benchmark(fun() -> benchmark_list(List) end)
             ]
         end,
         lists:seq(1, R)
     ),
-    [MarrayTimes, ListTimes] = lists:foldr(
-        fun([MarrayTime, ListTime], [MarrayTimes, ListTimes]) ->
-            [[MarrayTime| MarrayTimes],[ListTime | ListTimes]]
+    [MarrayErlangTimes, MarrayCTimes, ListTimes] = lists:foldr(
+        fun([MarrayErlangTime, MarrayCTime, ListTime], [MarrayErlangTimes, MarrayCTimes, ListTimes]) ->
+            [[MarrayErlangTime | MarrayErlangTimes], [MarrayCTime | MarrayCTimes],[ListTime | ListTimes]]
         end,
-        [[], []],
+        [[], [], []],
         ElapsedTimes
     ),
-    MarrayAvg = lists:sum(MarrayTimes) / length(MarrayTimes),
+    MarrayErlangAvg = lists:sum(MarrayErlangTimes) / length(MarrayErlangTimes),
+    MarrayCAvg = lists:sum(MarrayCTimes) / length(MarrayCTimes),
     ListAvg = lists:sum(ListTimes) / length(ListTimes),
-    MarrayMax = lists:max(MarrayTimes),
+    MarrayErlangMax = lists:max(MarrayErlangTimes),
+    MarrayCMax = lists:max(MarrayCTimes),
     ListMax = lists:max(ListTimes),
-    MarrayMin = lists:min(MarrayTimes),
+    MarrayErlangMin = lists:min(MarrayErlangTimes),
+    MarrayCMin = lists:min(MarrayCTimes),
     ListMin = lists:min(ListTimes),
-    MarrayStdDev = math:sqrt(lists:sum(lists:map(fun(X) -> math:pow(X - MarrayAvg, 2) end, MarrayTimes)) / length(MarrayTimes)),
+    MarrayErlangStdDev = math:sqrt(lists:sum(lists:map(fun(X) -> math:pow(X - MarrayErlangAvg, 2) end, MarrayErlangTimes)) / length(MarrayErlangTimes)),
+    MarrayCStdDev = math:sqrt(lists:sum(lists:map(fun(X) -> math:pow(X - MarrayCAvg, 2) end, MarrayCTimes)) / length(MarrayCTimes)),
     ListStdDev = math:sqrt(lists:sum(lists:map(fun(X) -> math:pow(X - ListAvg, 2) end, ListTimes)) / length(ListTimes)),
-    MarrayStdDev1 = round(MarrayStdDev * 100) / 100,
+    MarrayErlangStdDev1 = round(MarrayErlangStdDev * 100) / 100,
+    MarrayCStdDev1 = round(MarrayCStdDev * 100) / 100,
     ListStdDev1 = round(ListStdDev * 100) / 100,
-    io:format("Marray: avg=~p, max=~p, min=~p, stddev=~p~n", [MarrayAvg, MarrayMax, MarrayMin, MarrayStdDev1]),
-    io:format("List:   avg=~p, max=~p, min=~p, stddev=~p~n", [ListAvg, ListMax, ListMin, ListStdDev1]),
+    io:format("Marray(erlang): avg=~p, max=~p, min=~p, stddev=~p~n", [MarrayErlangAvg, MarrayErlangMax, MarrayErlangMin, MarrayErlangStdDev1]),
+    io:format("Marray(c):      avg=~p, max=~p, min=~p, stddev=~p~n", [MarrayCAvg, MarrayCMax, MarrayCMin, MarrayCStdDev1]),
+    io:format("List:           avg=~p, max=~p, min=~p, stddev=~p~n", [ListAvg, ListMax, ListMin, ListStdDev1]),
     ok;
 benchmark(_, _) ->
     usage().
 
-benchmark_marray(Marray) ->
-    sort(Marray, marray:size(Marray)).
+benchmark_marray(Marray, erlang) ->
+    sort(Marray, marray:size(Marray));
+benchmark_marray(Marray, c_sort) ->
+    marray:sort(Marray).
 
 sort(Marray, 0) ->
     Marray;
@@ -195,9 +204,4 @@ partition(_R, _L, I, _Pivot, _Marray) ->
     I.
 
 benchmark_list(List) ->
-    qsort(List).
-
-qsort([]) ->
-    [];
-qsort([Pivot | T]) ->
-    qsort([X || X <- T, X < Pivot]) ++ [Pivot] ++ qsort([X || X <- T, X >= Pivot]).
+    lists:sort(List).

--- a/c_src/marray.cpp
+++ b/c_src/marray.cpp
@@ -132,7 +132,7 @@ static ERL_NIF_TERM marray_set(ErlNifEnv *env, int argc,
   }
   if (index >= array->val->size()) {
     error = erlang::nif::error(env, "index out of bounds");
-    return error;
+    return enif_raise_exception(env, error);
   }
   array->val->_data[index] = argv[2];
 
@@ -156,10 +156,10 @@ static ERL_NIF_TERM marray_get(ErlNifEnv *env, int argc,
   }
   if (index >= array->val->size()) {
     error = erlang::nif::error(env, "index out of bounds");
-    return error;
+    return enif_raise_exception(env, error);
   }
 
-  return erlang::nif::ok(env, array->val->_data[index]);
+  return array->val->_data[index];
 }
 
 static ERL_NIF_TERM marray_swap(ErlNifEnv *env, int argc,

--- a/c_src/marray.cpp
+++ b/c_src/marray.cpp
@@ -200,6 +200,23 @@ static ERL_NIF_TERM marray_size(ErlNifEnv *env, int argc,
   return enif_make_uint64(env, array->val->size());
 }
 
+static ERL_NIF_TERM marray_sort(ErlNifEnv *env, int argc,
+                               const ERL_NIF_TERM argv[]) {
+  ERL_NIF_TERM ret{};
+  ERL_NIF_TERM error{};
+  marray_res * array = nullptr;
+  if (!enif_get_resource(env, argv[0], marray_res::type, reinterpret_cast<void **>(&array)) ||
+      array == nullptr) {
+    error = erlang::nif::error(env, "cannot access Nif resource");
+    return enif_raise_exception(env, error);
+  }
+
+  std::sort(array->val->_data.begin(), array->val->_data.end(), [](ERL_NIF_TERM a, ERL_NIF_TERM b) {
+    return enif_compare(a, b) < 0;
+  });
+  return argv[0];
+}
+
 static int on_load(ErlNifEnv *env, void **, ERL_NIF_TERM) {
   ErlNifResourceType *rt;
   rt = enif_open_resource_type(env, "marray_nif", "marray",
@@ -222,6 +239,7 @@ static ErlNifFunc nif_functions[] = {
     {"marray_get", 2, marray_get, 0},
     {"marray_swap", 3, marray_swap, 0},
     {"marray_size", 1, marray_size, 0},
+    {"marray_sort", 1, marray_sort, 0}
 };
 
 ERL_NIF_INIT(marray_nif, nif_functions, on_load, on_reload, on_upgrade, NULL);

--- a/src/marray.erl
+++ b/src/marray.erl
@@ -11,7 +11,8 @@
     set/3,
     get/2,
     swap/3,
-    size/1
+    size/1,
+    sort/1
 ]).
 
 new(Capacity, DefaultVal) ->
@@ -41,3 +42,6 @@ swap(MArray, IndexI, IndexJ) ->
 
 size(MArray) ->
     marray_nif:marray_size(MArray).
+
+sort(MArray) ->
+    marray_nif:marray_sort(MArray).

--- a/src/marray_nif.erl
+++ b/src/marray_nif.erl
@@ -44,3 +44,6 @@ marray_swap(_Marray, _IndexI, _IndexJ) ->
 
 marray_size(_Marray) ->
     not_loaded(?LINE).
+
+marray_sort(_Marray) ->
+    not_loaded(?LINE).


### PR DESCRIPTION
* Make sure results match (currently they do not)
* Avoid allocating intermediate lists
* Run in a separate process to avoid GC interference